### PR TITLE
bugfix: fix preview file cache issue

### DIFF
--- a/deploy/datasets/index.js
+++ b/deploy/datasets/index.js
@@ -25,6 +25,15 @@ const noCacheMiddleWare = (_req, res, next) => {
   next()
 }
 
+const getVary = (headers) => (_req, res, next) => {
+  if (!headers instanceof Array) {
+    console.warn(`getVary arguments needs to be an Array of string`)
+    return next()
+  }
+  res.setHeader('Vary', headers.join(', '))
+  next()
+}
+
 datasetsRouter.use('/spatialSearch', noCacheMiddleWare, require('./spatialRouter'))
 
 datasetsRouter.get('/templateName/:templateName', noCacheMiddleWare, (req, res, next) => {
@@ -59,7 +68,10 @@ datasetsRouter.get('/parcellationName/:parcellationName', noCacheMiddleWare, (re
     })
 })
 
-datasetsRouter.get('/preview/:datasetName', cacheMaxAge24Hr, (req, res, next) => {
+/**
+ * It appears that query param are not 
+ */
+datasetsRouter.get('/preview/:datasetName', getVary(['referer']), cacheMaxAge24Hr, (req, res, next) => {
   const { datasetName } = req.params
   const ref = url.parse(req.headers.referer)
   const { templateSelected, parcellationSelected } = qs.parse(ref.query)


### PR DESCRIPTION
previously whilst previewFiles intelligiently distinguish between MNI152 and colin27 via referer, the cache policy meant that the response is not updated. 

This PR should fix the issue, and will use referer as caching variable