### PR TITLE
bugfix strict species filter

### DIFF
--- a/deploy/datasets/supplements/commonSense.js
+++ b/deploy/datasets/supplements/commonSense.js
@@ -59,14 +59,5 @@ exports.getCommonSenseDsFilter = ({ templateName, parcellationName }) => {
         ? dsIsRat
         : null
 
-  const falseFilters = queryIsHuman({ templateName, parcellationName })
-    ? [dsIsMouse, dsIsRat]
-    : queryIsMouse({ templateName, parcellationName })
-      ? [dsIsHuman, dsIsRat]
-      : queryIsRat({ templateName, parcellationName })
-        ? [dsIsMouse, dsIsHuman]
-        : []
-  return ds => trueFilter
-    ? trueFilter({ ds }) || (falseFilters.every(filterFn => !filterFn({ ds })))
-    : false
+  return ds => trueFilter && trueFilter({ ds })
 }


### PR DESCRIPTION
monkey datasets with same brain region name are showing up in human template/parcellations

this PR requires the species to match that of the requested (i.e. request dataset in jubrain will return only datasets clearly labelled as homo sapien in species)