### PR TITLE
bugfix: fix occassional invalid access token

### DIFF
--- a/deploy/auth/util.js
+++ b/deploy/auth/util.js
@@ -38,7 +38,9 @@ const getPublicAccessToken = async () => {
 
   const decoded = jwtDecode(__publicAccessToken)
   const { exp } = decoded
-  if (!exp || isNaN(exp) || (exp * 1000 - Date.now() < 0)) {
+
+  // refresh token if it is less than 30 minute expiring
+  if (!exp || isNaN(exp) || (exp * 1000 - Date.now() < 1e3 * 60 * 30 )) {
     await refreshToken()
   }
   


### PR DESCRIPTION
Currently, exp property of access token is checked, and if unexpired, it will be used. 

This PR should now fetch access_token when it is some 30 minutes before exp