### PR TITLE
Modify explore in other templates for siibra api

### DIFF
--- a/common/util.js
+++ b/common/util.js
@@ -21,15 +21,15 @@
   }
 
   const HEMISPHERE = {
-    LEFT_HEMISPHERE: `left hemisphere`,
-    RIGHT_HEMISPHERE: `right hemisphere`
+    LEFT_HEMISPHERE: `left`,
+    RIGHT_HEMISPHERE: `right`
   }
 
   exports.getRegionHemisphere = region => {
     if (!region) return null
-    return (region.name && region.name.includes('- right hemisphere') || (!!region.status && region.status.includes('right hemisphere')))
+    return (region.name && region.name.includes(' right') || (!!region.status && region.status.includes('right')))
       ? HEMISPHERE.RIGHT_HEMISPHERE
-      : (region.name && region.name.includes('- left hemisphere') || (!!region.status && region.status.includes('left hemisphere')))
+      : (region.name && region.name.includes(' left') || (!!region.status && region.status.includes('left')))
         ? HEMISPHERE.LEFT_HEMISPHERE
         : null
   }


### PR DESCRIPTION
@xgui3783 Before we merge, the current approach is taken from the existing one. We are using `availableIn` field but still we are searching regions from the `fetchedTemplates`. 
As I mentioned, currently most regions do not have a centroid position, and look like it makes no sense to have `mni152 left` and `mni 152 right` into the `bigbrain` while exploring. 
The current approach works and of course we can use it (it almost never navigates after selecting exploring template) but I suggest 2 (maybe better) approaches.
 1 - keep a current list (e.g. `mni152 left` and `mni 152 right` when `bigbrain` is selected) and when the user clicks for example `mni152 left`, generate a new URL with selected template and selected region and open as a black page.
2 - simplify the list in Big Brain (e.g. have only `mni152` when `bigbrain` is selected) and do not navigate to the region after selecting a template (transformation coordination backend will work). this approach will make code more reliable.

What do you think?