### PR TITLE
hotfix: use redis store for rate limiting

### DIFF
--- a/deploy/saneUrl/index.js
+++ b/deploy/saneUrl/index.js
@@ -4,7 +4,7 @@ const { GitlabSnippetStore: Store, NotFoundError } = require('./store')
 const { Store: DepcStore } = require('./depcObjStore')
 const RateLimit = require('express-rate-limit')
 const RedisStore = require('rate-limit-redis')
-const { redisURL } = require('../lruStore')
+const lruStore = require('../lruStore')
 const { ProxyStore, NotExactlyPromiseAny } = require('./util')
 
 let store
@@ -23,12 +23,22 @@ const {
   DISABLE_LIMITER,
 } = process.env
 
-const limiter = new RateLimit({
-  windowMs: 1e3 * 5,
-  max: 5,
-  ...( redisURL ? { store: new RedisStore({ redisURL }) } : {} )
-})
-const passthrough = (_, __, next) => next()
+function limiterMiddleware(){
+  let limiter
+  return async (req, res, next) => {
+    if (DISABLE_LIMITER) return next()
+    if (limiter) return limiter(req, res, next)
+    await lruStore._initPr
+    const { redisURL } = lruStore
+    limiter = new RateLimit({
+      windowMs: 1e3 * 5,
+      max: 5,
+      store: redisURL ? new RedisStore({ redisURL }) : null
+    })
+    return limiter(req, res, next)
+  }
+}
+
 
 const acceptHtmlProg = /text\/html/i
 
@@ -85,7 +95,7 @@ router.get('/:name', async (req, res) => {
 })
 
 router.post('/:name',
-  DISABLE_LIMITER ? passthrough : limiter,
+  limiterMiddleware(),
   express.json(),
   async (req, res) => {
     if (req.headers['x-noop']) return res.status(200).end()

--- a/docs/releases/v2.6.5.md
+++ b/docs/releases/v2.6.5.md
@@ -4,3 +4,7 @@
 
 - Re-enabled autoradiographs for receptor datasets
 - Added how-to-cite as a part of quick tour (#1085)
+
+## Bugfix
+
+- saneUrl store now properly uses redis


### PR DESCRIPTION
previously, the implementation to use redis store to store potential offender's IP was not setup correctly. As a result, saneurl rate limiting had relied on local memory store. 

this would become inadequate when/if scaled up.

In fact, this issue was discovered when, it seems, OKD was configured to properly round robin the request. As a result, tests with threshold of 10 no longer trigger 429 (https://github.com/FZJ-INM1-BDA/iav-dep-test/runs/5156139391?check_suite_focus=true)